### PR TITLE
Fix generation to have namespace and move to 0000_90 for namespace

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,14 +3,16 @@ all: base rhel
 
 base:
 	echo "# Release verification against OpenShift CI keys" > \
-		manifests/0000_00_cluster-update-keys_configmap.yaml
-	oc create configmap release-verification -n openshift-config-managed \
+		manifests/0000_90_cluster-update-keys_configmap.yaml
+	oc create configmap release-verification \
 			--from-file=keys/verifier-public-key-openshift-ci \
 			--from-file=stores/store-openshift-ci-release \
 			--dry-run -o yaml | \
 		oc annotate -f - release.openshift.io/verification-config-map= \
-			--local --dry-run -o yaml	>> \
-		manifests/0000_00_cluster-update-keys_configmap.yaml
+			-n openshift-config-managed --local --dry-run -o yaml	>> \
+		manifests/0000_90_cluster-update-keys_configmap.yaml
+	echo "  namespace: openshift-config-managed" >> \
+		manifests/0000_90_cluster-update-keys_configmap.yaml
 .PHONY: base
 
 rhel:

--- a/manifests/0000_90_cluster-update-keys_configmap.yaml
+++ b/manifests/0000_90_cluster-update-keys_configmap.yaml
@@ -39,3 +39,4 @@ metadata:
     release.openshift.io/verification-config-map: ""
   creationTimestamp: null
   name: release-verification
+  namespace: openshift-config-managed


### PR DESCRIPTION
We want to be at the end so that openshift-config-managed exists
when the CVO tries to create this.