### PR TITLE
Add trusted keys to the CI stream

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
 FROM scratch
 COPY manifests/ /manifests/
-LABEL description="This image contains the trusted keys for the updates delivered to a cluster."
+LABEL description="This image contains the trusted keys for the updates delivered to a cluster." \
+      io.openshift.release.operator=true


### PR DESCRIPTION
This will enable CI builds to verify payloads against the release output.