### PR TITLE
Update Red Hat output to not create two files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ rhel:
 	cat keys/verifier-public-key-redhat-release > "$$keydir/verifier-public-key-redhat"; \
 	cat keys/verifier-public-key-redhat-beta-2 >> "$$keydir/verifier-public-key-redhat"; \
 	echo "# Release verification against Official Red Hat keys" > \
-		manifests.rhel/0000_00_cluster-update-keys_configmap.yaml; \
+		manifests.rhel/0000_90_cluster-update-keys_configmap.yaml; \
 	oc create configmap release-verification -n openshift-config-managed \
 			--from-file=$$keydir/verifier-public-key-redhat \
 			--from-file=stores/store-openshift-official-release \

--- a/manifests.rhel/0000_00_cluster-update-keys_configmap.yaml
+++ b/manifests.rhel/0000_00_cluster-update-keys_configmap.yaml
@@ -1,1 +1,0 @@
-# Release verification against Official Red Hat keys

--- a/manifests.rhel/0000_90_cluster-update-keys_configmap.yaml
+++ b/manifests.rhel/0000_90_cluster-update-keys_configmap.yaml
@@ -1,3 +1,4 @@
+# Release verification against Official Red Hat keys
 apiVersion: v1
 data:
   store-openshift-official-release: https://storage.googleapis.com/openshift-release/official/signatures/openshift/release


### PR DESCRIPTION
The comment was incorrectly output to a different file.