### PR TITLE
Concatenate keys into a single armored block

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ rhel:
 	gpg --dearmor < keys/verifier-public-key-redhat-release > "$$keydir/verifier-public-key-redhat.gpg"; \
 	gpg --dearmor < keys/verifier-public-key-redhat-beta-2 >> "$$keydir/verifier-public-key-redhat.gpg"; \
 	gpg --enarmor < "$$keydir/verifier-public-key-redhat.gpg" > "$$keydir/verifier-public-key-redhat"; \
+	sed -i 's/ARMORED FILE/PUBLIC KEY BLOCK/' "$$keydir/verifier-public-key-redhat"; \
 	echo "# Release verification against Official Red Hat keys" > \
 		manifests.rhel/0000_90_cluster-update-keys_configmap.yaml; \
 	oc create configmap release-verification -n openshift-config-managed \

--- a/Makefile
+++ b/Makefile
@@ -21,9 +21,10 @@ ci:
 # will remove the beta 2 key from the trust relationship. The signature storage is a bucket
 # on GCS and on mirror.openshift.com.
 rhel:
-	keydir=$(shell mktemp -d -t keys-XXXXXXXX); \
-	#cat keys/verifier-public-key-redhat-release > "$$keydir/verifier-public-key-redhat"; \
-	cat keys/verifier-public-key-redhat-beta-2 > "$$keydir/verifier-public-key-redhat"; \
+	keydir=$(shell mktemp -d -t keys); \
+	gpg --dearmor < keys/verifier-public-key-redhat-release > "$$keydir/verifier-public-key-redhat.gpg"; \
+	gpg --dearmor < keys/verifier-public-key-redhat-beta-2 >> "$$keydir/verifier-public-key-redhat.gpg"; \
+	gpg --enarmor < "$$keydir/verifier-public-key-redhat.gpg" > "$$keydir/verifier-public-key-redhat"; \
 	echo "# Release verification against Official Red Hat keys" > \
 		manifests.rhel/0000_90_cluster-update-keys_configmap.yaml; \
 	oc create configmap release-verification -n openshift-config-managed \

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ ci:
 # will remove the beta 2 key from the trust relationship. The signature storage is a bucket
 # on GCS and on mirror.openshift.com.
 rhel:
-	keydir=$(shell mktemp -d -t keys); \
+	keydir=$(shell mktemp -d -t keys-XXXXXXXX); \
 	gpg --dearmor < keys/verifier-public-key-redhat-release > "$$keydir/verifier-public-key-redhat.gpg"; \
 	gpg --dearmor < keys/verifier-public-key-redhat-beta-2 >> "$$keydir/verifier-public-key-redhat.gpg"; \
 	gpg --enarmor < "$$keydir/verifier-public-key-redhat.gpg" > "$$keydir/verifier-public-key-redhat"; \

--- a/manifests.rhel/0000_90_cluster-update-keys_configmap.yaml
+++ b/manifests.rhel/0000_90_cluster-update-keys_configmap.yaml
@@ -3,37 +3,59 @@ apiVersion: v1
 data:
   store-openshift-official-release: https://storage.googleapis.com/openshift-release/official/signatures/openshift/release
   store-openshift-official-release-mirror: https://mirror.openshift.com/pub/openshift-v4/signatures/openshift/release
-  verifier-public-key-redhat: |-
-    4096R/F21541EB 2009-02-24 Red Hat, Inc. (beta key 2) <security@redhat.com>
-
+  verifier-public-key-redhat: |
     -----BEGIN PGP PUBLIC KEY BLOCK-----
-    Version: GnuPG v1.2.6 (GNU/Linux)
+    Comment: Use "gpg --dearmor" for unpacking
 
-    mQINBEmkAzABEAC2/c7bP1lHQ3XScxbIk0LQWe1YOiibQBRLwf8Si5PktgtuPibT
-    kKpZjw8p4D+fM7jD1WUzUE0X7tXg2l/eUlMM4dw6XJAQ1AmEOtlwSg7rrMtTvM0A
-    BEtI7Km6fC6sU6RtBMdcqD1cH/6dbsfh8muznVA7UlX+PRBHVzdWzj6y8h84dBjo
-    gzcbYu9Hezqgj/lLzicqsSZPz9UdXiRTRAIhp8V30BD8uRaaa0KDDnD6IzJv3D9P
-    xQWbFM4Z12GN9LyeZqmD7bpKzZmXG/3drvfXVisXaXp3M07t3NlBa3Dt8NFIKZ0D
-    FRXBz5bvzxRVmdH6DtkDWXDPOt+Wdm1rZrCOrySFpBZQRpHw12eo1M1lirANIov7
-    Z+V1Qh/aBxj5EUu32u9ZpjAPPNtQF6F/KjaoHHHmEQAuj4DLex4LY646Hv1rcv2i
-    QFuCdvLKQGSiFBrfZH0j/IX3/0JXQlZzb3MuMFPxLXGAoAV9UP/Sw/WTmAuTzFVm
-    G13UYFeMwrToOiqcX2VcK0aC1FCcTP2z4JW3PsWvU8rUDRUYfoXovc7eg4Vn5wHt
-    0NBYsNhYiAAf320AUIHzQZYi38JgVwuJfFu43tJZE4Vig++RQq6tsEx9Ftz3EwRR
-    fJ9z9mEvEiieZm+vbOvMvIuimFVPSCmLH+bI649K8eZlVRWsx3EXCVb0nQARAQAB
-    tDBSZWQgSGF0LCBJbmMuIChiZXRhIGtleSAyKSA8c2VjdXJpdHlAcmVkaGF0LmNv
-    bT6JAjYEEwECACAFAkpSM+cCGwMGCwkIBwMCBBUCCAMEFgIDAQIeAQIXgAAKCRCT
-    ioDK8hVB6/9tEAC0+KmzeKceXQ/GTUoU6jy9vtkFCFrmv+c7ol4XpdTt0QhqBOwy
-    6m2mKWwmm8KfYfy0cADQ4y/EcoXl7FtFBwYmkCuEQGXhTDn9DvVjhooIq59LEMBQ
-    OW879RwwzRIZ8ebbjMUjDPF5MfPQqP2LBu9N4KvXlZp4voykwuuaJ+cbsKZR6pZ6
-    0RQKPHKP+NgUFC0fff7XY9cuOZZWFAeKRhLN2K7bnRHKxp+kELWb6R9ZfrYwZjWc
-    MIPbTd1khE53L4NTfpWfAnJRtkPSDOKEGVlVLtLq4HEAxQt07kbslqISRWyXER3u
-    QOJj64D1ZiIMz6t6uZ424VE4ry9rBR0Jz55cMMx5O/ni9x3xzFUgH8Su2yM0r3jE
-    Rf24+tbOaPf7tebyx4OKe+JW95hNVstWUDyGbs6K9qGfI/pICuO1nMMFTo6GqzQ6
-    DwLZvJ9QdXo7ujEtySZnfu42aycaQ9ZLC2DOCQCUBY350Hx6FLW3O546TAvpTfk0
-    B6x+DV7mJQH7MGmRXQsE7TLBJKjq28Cn4tVp04PmybQyTxZdGA/8zY6pPl6xyVMH
-    V68hSBKEVT/rlouOHuxfdmZva1DhVvUC6Xj7+iTMTVJUAq/4Uyn31P1OJmA2a0PT
-    CAqWkbJSgKFccsjPoTbLyxhuMSNkEZFHvlZrSK9vnPzmfiRH0Orx3wYpMQ==
-    =21pb
+    mQINBErgSTsBEACh2A4b0O9t+vzC9VrVtL1AKvUWi9OPCjkvR7Xd8DtJxeeMZ5eF
+    0HtzIG58qDRybwUe89FZprB1ffuUKzdE+HcL3FbNWSSOXVjZIersdXyH3NvnLLLF
+    0DNRB2ix3bXG9Rh/RXpFsNxDp2CEMdUvbYCzE79K1EnUTVh1L0Of023FtPSZXX0c
+    u7Pb5DI5lX5YeoXO6RoodrIGYJsVBQWnrWw4xNTconUfNPk0EGZtEnzvH2zyPoJh
+    XGF+Ncu9XwbalnYde10OCvSWAZ5zTCpoLMTvQjWpbCdWXJzCm6G+/hx9upke546H
+    5IjtYm4dTIVTnc3wvDiODgBKRzOl9rEOCIgOuGtDxRxcQkjrC+xvg5Vkqn7vBUyW
+    9pHedOU+PoF3DGOM+dqv+eNKBvh9YF9ugFAQBkcG7viZgvGEMGGUpzNgN7XnS1gj
+    /DPo9mZESOYnKceve2tIC87p2hqjrxOHuI7fkZYeNIcAoa83rBltFXaBDYhWAKS1
+    PcXS1/7JzP0ky7d0L6Xbu/If5kqWQpKwUInXtySRkuraVfuK3Bpa+X1XecWi24JY
+    HVtlNX025xx1ewVzGNCTlWn1skQN2OOoQTV4C8/qFpTW6DTWYurd4+fE0OJFJZQF
+    buhfXYwmRlVOgN5i77NTIJZJQfYFj38c/Iv5vZBPokO6mffrOTv3MHWVgQARAQAB
+    tDNSZWQgSGF0LCBJbmMuIChyZWxlYXNlIGtleSAyKSA8c2VjdXJpdHlAcmVkaGF0
+    LmNvbT6JAjYEEwECACAFAkrgSTsCGwMGCwkIBwMCBBUCCAMEFgIDAQIeAQIXgAAK
+    CRAZni+R/UMdUWzpD/9s5SFR/ZF3yjY5VLUFLMXIKUztNN3oc45fyLdTI3+UClKC
+    2tEruzYjqNHhqAEXa2sN1fMrsuKec61Ll2NfvJjkLKDvgVIh7kM7aslNYVOP6BTf
+    C/JJ7/ufz3UZmyViH/WDl+AYdgk3JqCIO5w5ryrC9IyBzYv2m0HqYbWfphY3uHw5
+    un3ndLJcu8+BGP5F+ONQEGl+DRH58Il9Jp3HwbRa7dvkPgEhfFR+1hI+Btta2C7E
+    0/2NKzCxZw7Lx3PBRcU92YKyaEihfy/aQKZCAuyfKiMvsmzs+4poIX7I9NQCJpyE
+    IGfINoZ7VxqHwRn/d5mw2MZTJjbzSf+Um9YJyA0iEEyD6qjriWQRbuxpQXmlAJbh
+    8okZ4gbVFv1F8MzK+4R8VvWJ0XxgtikSo72fHjwha7MAjqFnOq6eo6fEC/75g3NL
+    Ght5VdpGuHk0vbdENHMC8wS99e5qXGNDued3hlTavDMlEAHl34q2H9nakTGRF5Ki
+    JUfNh3DVRGhg8cMIti21njiRh7gyFI2OccATY7bBSr79JhuNwelHuxLrCFpY7V25
+    OFktl15jZJaMxuQBqYdBgSay2G0U6D1+7VsWufpzd/Abx1/c3oi9ZaJvW22kAggq
+    dzdA27UUYjWvx42w9menJwh/0jeQcTecIUd0d0rFcw/c1pvgMMl/Q73yzKgKY5kC
+    DQRJpAMwARAAtv3O2z9ZR0N10nMWyJNC0FntWDoom0AUS8H/EouT5LYLbj4m05Cq
+    WY8PKeA/nzO4w9VlM1BNF+7V4Npf3lJTDOHcOlyQENQJhDrZcEoO66zLU7zNAARL
+    SOypunwurFOkbQTHXKg9XB/+nW7H4fJrs51QO1JV/j0QR1c3Vs4+svIfOHQY6IM3
+    G2LvR3s6oI/5S84nKrEmT8/VHV4kU0QCIafFd9AQ/LkWmmtCgw5w+iMyb9w/T8UF
+    mxTOGddhjfS8nmapg+26Ss2Zlxv93a7311YrF2l6dzNO7dzZQWtw7fDRSCmdAxUV
+    wc+W788UVZnR+g7ZA1lwzzrflnZta2awjq8khaQWUEaR8NdnqNTNZYqwDSKL+2fl
+    dUIf2gcY+RFLt9rvWaYwDzzbUBehfyo2qBxx5hEALo+Ay3seC2OuOh79a3L9okBb
+    gnbyykBkohQa32R9I/yF9/9CV0JWc29zLjBT8S1xgKAFfVD/0sP1k5gLk8xVZhtd
+    1GBXjMK06DoqnF9lXCtGgtRQnEz9s+CVtz7Fr1PK1A0VGH6F6L3O3oOFZ+cB7dDQ
+    WLDYWIgAH99tAFCB80GWIt/CYFcLiXxbuN7SWROFYoPvkUKurbBMfRbc9xMEUXyf
+    c/ZhLxIonmZvr2zrzLyLophVT0gpix/myOuPSvHmZVUVrMdxFwlW9J0AEQEAAbQw
+    UmVkIEhhdCwgSW5jLiAoYmV0YSBrZXkgMikgPHNlY3VyaXR5QHJlZGhhdC5jb20+
+    iQI2BBMBAgAgBQJKUjPnAhsDBgsJCAcDAgQVAggDBBYCAwECHgECF4AACgkQk4qA
+    yvIVQev/bRAAtPips3inHl0Pxk1KFOo8vb7ZBQha5r/nO6JeF6XU7dEIagTsMupt
+    pilsJpvCn2H8tHAA0OMvxHKF5exbRQcGJpArhEBl4Uw5/Q71Y4aKCKufSxDAUDlv
+    O/UcMM0SGfHm24zFIwzxeTHz0Kj9iwbvTeCr15WaeL6MpMLrmifnG7CmUeqWetEU
+    Cjxyj/jYFBQtH33+12PXLjmWVhQHikYSzdiu250RysafpBC1m+kfWX62MGY1nDCD
+    203dZIROdy+DU36VnwJyUbZD0gzihBlZVS7S6uBxAMULdO5G7JaiEkVslxEd7kDi
+    Y+uA9WYiDM+rermeNuFROK8vawUdCc+eXDDMeTv54vcd8cxVIB/ErtsjNK94xEX9
+    uPrWzmj3+7Xm8seDinviVveYTVbLVlA8hm7OivahnyP6SArjtZzDBU6Ohqs0Og8C
+    2byfUHV6O7oxLckmZ37uNmsnGkPWSwtgzgkAlAWN+dB8ehS1tzueOkwL6U35NAes
+    fg1e5iUB+zBpkV0LBO0ywSSo6tvAp+LVadOD5sm0Mk8WXRgP/M2OqT5esclTB1ev
+    IUgShFU/65aLjh7sX3Zmb2tQ4Vb1Aul4+/okzE1SVAKv+FMp99T9TiZgNmtD0wgK
+    lpGyUoChXHLIz6E2y8sYbjEjZBGRR75Wa0ivb5z85n4kR9Dq8d8GKTE=
+    =syRO
     -----END PGP PUBLIC KEY BLOCK-----
 kind: ConfigMap
 metadata:


### PR DESCRIPTION
The ReadArmoredKeyRing() function from Golang's OpenPGP library only
supports reading from a single armored block. Instead of concatenating
the two armored keys together, the keys need to be dearmored,
concatenated, and then armored. This will allow the OpenPGP library to
read both keys into the keyring.

The resulting armored block looks as follows:
```
$ gpg --list-packets
:public key packet:
	version 4, algo 1, created 1256212795, expires 0
	pkey[0]: [4096 bits]
	pkey[1]: [17 bits]
	keyid: 199E2F91FD431D51
:user ID packet: "Red Hat, Inc. (release key 2) <security@redhat.com>"
:signature packet: algo 1, keyid 199E2F91FD431D51
	version 4, created 1256212795, md5len 0, sigclass 0x13
	digest algo 2, begin of digest 6c e9
	hashed subpkt 2 len 4 (sig created 2009-10-22)
	hashed subpkt 27 len 1 (key flags: 03)
	hashed subpkt 11 len 5 (pref-sym-algos: 9 8 7 3 2)
	hashed subpkt 21 len 3 (pref-hash-algos: 2 8 3)
	hashed subpkt 22 len 3 (pref-zip-algos: 2 3 1)
	hashed subpkt 30 len 1 (features: 01)
	hashed subpkt 23 len 1 (keyserver preferences: 80)
	subpkt 16 len 8 (issuer key ID 199E2F91FD431D51)
	data: [4095 bits]
:public key packet:
	version 4, algo 1, created 1235485488, expires 0
	pkey[0]: [4096 bits]
	pkey[1]: [17 bits]
	keyid: 938A80CAF21541EB
:user ID packet: "Red Hat, Inc. (beta key 2) <security@redhat.com>"
:signature packet: algo 1, keyid 938A80CAF21541EB
	version 4, created 1246901223, md5len 0, sigclass 0x13
	digest algo 2, begin of digest ff 6d
	hashed subpkt 2 len 4 (sig created 2009-07-06)
	hashed subpkt 27 len 1 (key flags: 03)
	hashed subpkt 11 len 5 (pref-sym-algos: 9 8 7 3 2)
	hashed subpkt 21 len 3 (pref-hash-algos: 2 8 3)
	hashed subpkt 22 len 3 (pref-zip-algos: 2 3 1)
	hashed subpkt 30 len 1 (features: 01)
	hashed subpkt 23 len 1 (keyserver preferences: 80)
	subpkt 16 len 8 (issuer key ID 938A80CAF21541EB)
	data: [4096 bits]
```