### PR TITLE
mktemp -t requires a template on linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ ci:
 # will remove the beta 2 key from the trust relationship. The signature storage is a bucket
 # on GCS and on mirror.openshift.com.
 rhel:
-	keydir=$(shell mktemp -d -t keys); \
+	keydir=$(shell mktemp -d -t keys-XXXXXXXX); \
 	gpg --dearmor < keys/verifier-public-key-redhat-release > "$$keydir/verifier-public-key-redhat.gpg"; \
 	gpg --dearmor < keys/verifier-public-key-redhat-beta-2 >> "$$keydir/verifier-public-key-redhat.gpg"; \
 	gpg --enarmor < "$$keydir/verifier-public-key-redhat.gpg" > "$$keydir/verifier-public-key-redhat"; \


### PR DESCRIPTION
mktemp -t on modern coreutils says 'template' which requires a block of XXX
to be templatized. On mac -t does not use a template. This means that on linux
we'll get a file like    keys-deadbeef and on mac we'll get keys-XXXXXXXX-deadbeef
but who cares, it's a random file either way. And now it actually works on linux.