### PR TITLE
"BEGIN PGP ARMORED FILE" -> "BEGIN PGP PUBLIC KEY BLOCK" for Go

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ rhel:
 	gpg --dearmor < keys/verifier-public-key-redhat-release > "$$keydir/verifier-public-key-redhat.gpg"; \
 	gpg --dearmor < keys/verifier-public-key-redhat-beta-2 >> "$$keydir/verifier-public-key-redhat.gpg"; \
 	gpg --enarmor < "$$keydir/verifier-public-key-redhat.gpg" > "$$keydir/verifier-public-key-redhat"; \
+	sed -i 's/ARMORED FILE/PUBLIC KEY BLOCK/' "$$keydir/verifier-public-key-redhat"; \
 	echo "# Release verification against Official Red Hat keys" > \
 		manifests.rhel/0000_90_cluster-update-keys_configmap.yaml; \
 	oc create configmap release-verification -n openshift-config-managed \

--- a/manifests.rhel/0000_90_cluster-update-keys_configmap.yaml
+++ b/manifests.rhel/0000_90_cluster-update-keys_configmap.yaml
@@ -4,7 +4,7 @@ data:
   store-openshift-official-release: https://storage.googleapis.com/openshift-release/official/signatures/openshift/release
   store-openshift-official-release-mirror: https://mirror.openshift.com/pub/openshift-v4/signatures/openshift/release
   verifier-public-key-redhat: |
-    -----BEGIN PGP ARMORED FILE-----
+    -----BEGIN PGP PUBLIC KEY BLOCK-----
     Comment: Use "gpg --dearmor" for unpacking
 
     mQINBErgSTsBEACh2A4b0O9t+vzC9VrVtL1AKvUWi9OPCjkvR7Xd8DtJxeeMZ5eF
@@ -56,7 +56,7 @@ data:
     IUgShFU/65aLjh7sX3Zmb2tQ4Vb1Aul4+/okzE1SVAKv+FMp99T9TiZgNmtD0wgK
     lpGyUoChXHLIz6E2y8sYbjEjZBGRR75Wa0ivb5z85n4kR9Dq8d8GKTE=
     =syRO
-    -----END PGP ARMORED FILE-----
+    -----END PGP PUBLIC KEY BLOCK-----
 kind: ConfigMap
 metadata:
   annotations:


### PR DESCRIPTION
[Go's parser requires the well-known labels][1] (openshift/cluster-version-operator#196).

[1]: https://github.com/golang/crypto/blob/20be4c3c3ed52bfccdb2d59a412ee1a936d175a7/openpgp/keys.go#L244