### PR TITLE
Update CI search location to match where release signer publishes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ all: ci rhel
 
 # The CI system uses the OpenShift CI public key and verifies it against a bucket on GCS.
 ci:
-	echo "# Release verification against OpenShift CI keys" > \
+	echo "# Release verification against OpenShift CI keys signed by the CI infrastructure" > \
 		manifests/0000_90_cluster-update-keys_configmap.yaml
 	oc create configmap release-verification \
 			--from-file=keys/verifier-public-key-openshift-ci \

--- a/manifests/0000_90_cluster-update-keys_configmap.yaml
+++ b/manifests/0000_90_cluster-update-keys_configmap.yaml
@@ -1,7 +1,7 @@
-# Release verification against OpenShift CI keys
+# Release verification against OpenShift CI keys signed by the CI infrastructure
 apiVersion: v1
 data:
-  store-openshift-ci-release: https://storage.googleapis.com/openshift-release/test-1/signatures/openshift/release
+  store-openshift-ci-release: https://storage.googleapis.com/openshift-ci-release/releases/signatures/openshift/release
   verifier-public-key-openshift-ci: |-
     -----BEGIN PGP PUBLIC KEY BLOCK-----
 

--- a/stores/store-openshift-ci-release
+++ b/stores/store-openshift-ci-release
@@ -1,1 +1,1 @@
-https://storage.googleapis.com/openshift-release/test-1/signatures/openshift/release
+https://storage.googleapis.com/openshift-ci-release/releases/signatures/openshift/release


### PR DESCRIPTION
The official URL is gs://openshift-ci-release/releases/... to distinguish CI signing from OCP signing.