### PR TITLE
Pack both keys in one verifier-public-key-ci entry

### DIFF
--- a/manifests/0000_90_cluster-update-keys_configmap.yaml
+++ b/manifests/0000_90_cluster-update-keys_configmap.yaml
@@ -2,8 +2,9 @@
 apiVersion: v1
 data:
   store-openshift-ci-release: https://storage.googleapis.com/openshift-ci-release/releases/signatures/openshift/release
-  verifier-public-key-openshift-ci: |-
+  verifier-public-key-ci: |
     -----BEGIN PGP PUBLIC KEY BLOCK-----
+    Comment: Use "gpg --dearmor" for unpacking
 
     mQENBFy9Q6sBCAD1MvcwX9f1Vu/M/dh+SJYbuAP4urtZZ7YoZOlzo6lw/xDF9z0E
     ef8BXAtO7YMStfbxn5Rqb3kPnA20CRXraW4PqA5mB37ubDGThxb8catCTeWpd/5o
@@ -30,40 +31,34 @@ data:
     gm61vHfbviKSyQg3hpKG8/g2sFgQ9CNi5DFghIYesp+7NwCC+UOVGBu90O4SIq+I
     Ms2n3OTR2GIEz0LgEvC/3R7pkBNjLNTccExBNqOShJy3XnwntvYflxVwEBVsyEbK
     LvLU2xtlIE/IdGssKQR8UFFsgFmGiX3t1TcahFnLlr6Et+vB4J02Xr+uvZ81v/Zq
-    1OHz7iIjrd28MslYu24=
-    =xMCa
-    -----END PGP PUBLIC KEY BLOCK-----
-  verifier-public-key-openshift-ci-2: |
-    -----BEGIN PGP PUBLIC KEY BLOCK-----
-    Version: BCPG v1.63
-
-    mQINBGCIN7cBEADMU21mvdiAgm5zQiaP7qF2ldj5udH9KII+kD8LIQy0s8ITQSmE
-    iq2oJ58HuprRS6Zyorz9N8XVf+ivVRV71Ii5+0b5ErXz1b1kp/WzqxxlCdmOXW3E
-    o4E665lNWLrrWNEtzguOdZ9LwDsUBoCSmaDB0aqHHZWk2jxtHuUmdsKS9K2ySowI
-    67uUWl3WokUiLShhDdpqF3tWQ8BtOelsi621bypfJfXkki/vlgNN+gYkkxzDpHlC
-    ckqh4THhw/rtvcXtMUGT0b1PMxK8xLn5WM7fkd1VXyrRG6FJsBBk4bPP7Y8PAXqN
-    rfpmybpx6UPr8iOtWuuvmsIOFk1e7+zz72/Dn9ZzXLgZeNmYNDbfAgg85UAc1jEJ
-    wkswcJzRmv4Yi185Bv3A/+VmiK/NImPePBa3J6gsWGa93Fi4cxNeESWh986j0fmf
-    pad6C/VflZeKtOcrXNBexjPv6KAk4fXz3lFI3UQBN9fNgrF8sf4WKOeQ16MZixPB
-    QYcxM+F656z0PMMjsYo040c/a2anxbHgzXNSQI0qkNurkOUYA05TTtDzo5S2iref
-    j74kTD+znyBTgrTmoacT3fhhrlp4koFZsMEePejwtHsmD48PZPBK6NpGAjbaO1Xi
-    sAPLdYGINT/8iN4WB/NS0LeYYkl9ZHZxghIeet7lU432mkqKYjKQbyQI1wARAQAB
-    tG9vcGVuc2hpZnQtY2ktcmVsZWFzZS1rZXkgKFRoaXMga2V5IGlzIHVzZWQgdG8g
-    c2lnbiByZWxlYXNlcyBmcm9tIHRoZSBPcGVuU2hpZnQgQ0kgc3lzdGVtKSA8Y2Nv
-    bGVtYW5AcmVkaGF0LmNvbT6JAlQEEwEIAD4WIQQgzMetJy3NOqFp8SplwoNx9V0p
-    qQUCYIg3twIbAwUJA8JnAAULCQgHAgYVCgkICwIEFgIDAQIeAQIXgAAKCRBlwoNx
-    9V0pqXljEACt30mVRfi5gnWoEq7HWoc6QTdARLbeLf4Zo0LxcgnZMG5/btbrz0tl
-    ymefnwV24o28bO0wnAxYS0+wVEope2PBf+PRk6WHGHg/+0q/cmAirrOh44tyONjZ
-    kCioaqIeir8r02eC0dFmAkItKgv85sNF7XPnJk7kPgP4JAIWCijeEa1Y/LvT0JP3
-    HpL7r0hxRVM8TOkULZphkezYXKRIik5BJ3DFYXMsyLc97VKb7afyKd6b1BclkBDv
-    FVFQtPBEVpfJ0l7vPoQ05YT+RwR9VE7Bgws8JE1uOAOMwMEp3FgVtMhd88OlJc0t
-    +wbcFVYbsVtw4S9M28lLRzp+DF+Lzmfu3vrfk7ptb1N0wPt8p20lbL6sHs9INclH
-    pV0eCqf0B/IQU+8loJAFZ1Eri5kO9IugG7pLp+B8E2AZwZEqB2BVveoGi4Bf+yug
-    Vs0AjmrJIw7Bc/JAwdVOa8e918tIVdyYay1InPQVO2t8R7maKveIyvYagJq5JlJS
-    xtyi+JEMsrCkuAoPBzED2tqVOoIVxR3gU9v5bR2u+U6vDnDsduj5/Ept2s7qYtII
-    yvNuntPtaM+MMZoG7uyDsdULjQpefn/JjFp5YWPkb+lIWhASFXmzLGStzA8nQF72
-    SybvVav2YSz2YScI6ytxWUNzdQXRbqM/NUd2Ou1ycnybi0BiGeALYA==
-    =v1yy
+    1OHz7iIjrd28MslYu26ZAg0EYIg3twEQAMxTbWa92ICCbnNCJo/uoXaV2Pm50f0o
+    gj6QPwshDLSzwhNBKYSKragnnwe6mtFLpnKivP03xdV/6K9VFXvUiLn7RvkStfPV
+    vWSn9bOrHGUJ2Y5dbcSjgTrrmU1YuutY0S3OC451n0vAOxQGgJKZoMHRqocdlaTa
+    PG0e5SZ2wpL0rbJKjAjru5RaXdaiRSItKGEN2moXe1ZDwG056WyLrbVvKl8l9eSS
+    L++WA036BiSTHMOkeUJySqHhMeHD+u29xe0xQZPRvU8zErzEuflYzt+R3VVfKtEb
+    oUmwEGThs8/tjw8Beo2t+mbJunHpQ+vyI61a66+awg4WTV7v7PPvb8Of1nNcuBl4
+    2Zg0Nt8CCDzlQBzWMQnCSzBwnNGa/hiLXzkG/cD/5WaIr80iY948FrcnqCxYZr3c
+    WLhzE14RJaH3zqPR+Z+lp3oL9V+Vl4q05ytc0F7GM+/ooCTh9fPeUUjdRAE3182C
+    sXyx/hYo55DXoxmLE8FBhzEz4XrnrPQ8wyOxijTjRz9rZqfFseDNc1JAjSqQ26uQ
+    5RgDTlNO0POjlLaKt5+PviRMP7OfIFOCtOahpxPd+GGuWniSgVmwwR496PC0eyYP
+    jw9k8Ero2kYCNto7VeKwA8t1gYg1P/yI3hYH81LQt5hiSX1kdnGCEh563uVTjfaa
+    SopiMpBvJAjXABEBAAG0b29wZW5zaGlmdC1jaS1yZWxlYXNlLWtleSAoVGhpcyBr
+    ZXkgaXMgdXNlZCB0byBzaWduIHJlbGVhc2VzIGZyb20gdGhlIE9wZW5TaGlmdCBD
+    SSBzeXN0ZW0pIDxjY29sZW1hbkByZWRoYXQuY29tPokCVAQTAQgAPhYhBCDMx60n
+    Lc06oWnxKmXCg3H1XSmpBQJgiDe3AhsDBQkDwmcABQsJCAcCBhUKCQgLAgQWAgMB
+    Ah4BAheAAAoJEGXCg3H1XSmpeWMQAK3fSZVF+LmCdagSrsdahzpBN0BEtt4t/hmj
+    QvFyCdkwbn9u1uvPS2XKZ5+fBXbijbxs7TCcDFhLT7BUSil7Y8F/49GTpYcYeD/7
+    Sr9yYCKus6Hji3I42NmQKKhqoh6KvyvTZ4LR0WYCQi0qC/zmw0Xtc+cmTuQ+A/gk
+    AhYKKN4RrVj8u9PQk/cekvuvSHFFUzxM6RQtmmGR7NhcpEiKTkEncMVhcyzItz3t
+    Upvtp/Ip3pvUFyWQEO8VUVC08ERWl8nSXu8+hDTlhP5HBH1UTsGDCzwkTW44A4zA
+    wSncWBW0yF3zw6UlzS37BtwVVhuxW3DhL0zbyUtHOn4MX4vOZ+7e+t+Tum1vU3TA
+    +3ynbSVsvqwez0g1yUelXR4Kp/QH8hBT7yWgkAVnUSuLmQ70i6Abukun4HwTYBnB
+    kSoHYFW96gaLgF/7K6BWzQCOaskjDsFz8kDB1U5rx73Xy0hV3JhrLUic9BU7a3xH
+    uZoq94jK9hqAmrkmUlLG3KL4kQyysKS4Cg8HMQPa2pU6ghXFHeBT2/ltHa75Tq8O
+    cOx26Pn8Sm3azupi0gjK826e0+1oz4wxmgbu7IOx1QuNCl5+f8mMWnlhY+Rv6Uha
+    EBIVebMsZK3MDydAXvZLJu9Vq/ZhLPZhJwjrK3FZQ3N1BdFuoz81R3Y67XJyfJuL
+    QGIZ4Atg
+    =ZfMr
     -----END PGP PUBLIC KEY BLOCK-----
 kind: ConfigMap
 metadata:


### PR DESCRIPTION
Two configmap keys means "must be signed by both keys". What we want instead is "signed by either key".
In order to archive that both keys need to be dearmored, concatenated and armored back.