### PR TITLE
Add script generating configmaps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,52 +1,26 @@
+ci_keys = keys/verifier-public-key-openshift-ci keys/verifier-public-key-openshift-ci-2
+ci_stores = stores/store-openshift-ci-release
+ci_manifests = manifests/0000_90_cluster-update-keys_configmap.yaml
+rhel_keys = keys/verifier-public-key-redhat-release keys/verifier-public-key-redhat-beta-2
+rhel_stores = stores/store-openshift-official-release stores/store-openshift-official-release-mirror
+rhel_manifests = manifests.rhel/0000_90_cluster-update-keys_configmap.yaml
+
 all: ci rhel
 .PHONY: all
 
 # The CI system uses the OpenShift CI public key and verifies it against a bucket on GCS.
-ci:
-	keydir=$(shell mktemp -d -t keys-XXXXXXXX); \
-	gpg --dearmor < keys/verifier-public-key-openshift-ci > "$$keydir/verifier-public-key-ci.gpg"; \
-	gpg --dearmor < keys/verifier-public-key-openshift-ci-2 >> "$$keydir/verifier-public-key-ci.gpg"; \
-	gpg --enarmor < "$$keydir/verifier-public-key-ci.gpg" > "$$keydir/verifier-public-key-ci"; \
-	sed -i 's/ARMORED FILE/PUBLIC KEY BLOCK/' "$$keydir/verifier-public-key-ci"; \
-	echo "# Release verification against OpenShift CI keys signed by the CI infrastructure" > \
-		manifests/0000_90_cluster-update-keys_configmap.yaml; \
-	oc create configmap release-verification \
-			--from-file=$$keydir/verifier-public-key-ci \
-			--from-file=stores/store-openshift-ci-release \
-			--dry-run -o yaml | \
-		oc annotate -f - release.openshift.io/verification-config-map= \
-			include.release.openshift.io/ibm-cloud-managed="true" \
-			include.release.openshift.io/self-managed-high-availability="true" \
-			include.release.openshift.io/single-node-developer="true" \
-			-n openshift-config-managed --local --dry-run=client -o yaml	>> \
-		manifests/0000_90_cluster-update-keys_configmap.yaml; \
-	echo "  namespace: openshift-config-managed" >> \
-		manifests/0000_90_cluster-update-keys_configmap.yaml
+ci: $(ci_manifests)
 .PHONY: ci
 
 # The Red Hat release contains the two primary Red Hat release keys from
 # https://access.redhat.com/security/team/key as well as the beta 2 key. A future release
 # will remove the beta 2 key from the trust relationship. The signature storage is a bucket
 # on GCS and on mirror.openshift.com.
-rhel:
-	keydir=$(shell mktemp -d -t keys-XXXXXXXX); \
-	gpg --dearmor < keys/verifier-public-key-redhat-release > "$$keydir/verifier-public-key-redhat.gpg"; \
-	gpg --dearmor < keys/verifier-public-key-redhat-beta-2 >> "$$keydir/verifier-public-key-redhat.gpg"; \
-	gpg --enarmor < "$$keydir/verifier-public-key-redhat.gpg" > "$$keydir/verifier-public-key-redhat"; \
-	sed -i 's/ARMORED FILE/PUBLIC KEY BLOCK/' "$$keydir/verifier-public-key-redhat"; \
-	echo "# Release verification against Official Red Hat keys" > \
-		manifests.rhel/0000_90_cluster-update-keys_configmap.yaml; \
-	oc create configmap release-verification -n openshift-config-managed \
-			--from-file=$$keydir/verifier-public-key-redhat \
-			--from-file=stores/store-openshift-official-release \
-			--from-file=stores/store-openshift-official-release-mirror \
-			--dry-run=client -o yaml | \
-		oc annotate -f - release.openshift.io/verification-config-map= \
-			include.release.openshift.io/ibm-cloud-managed="true" \
-			include.release.openshift.io/self-managed-high-availability="true" \
-			include.release.openshift.io/single-node-developer="true" \
-			-n openshift-config-managed --local --dry-run=client -o yaml	>> \
-		manifests.rhel/0000_90_cluster-update-keys_configmap.yaml; \
-	echo "  namespace: openshift-config-managed" >> \
-		manifests.rhel/0000_90_cluster-update-keys_configmap.yaml
+rhel: $(rhel_manifests)
 .PHONY: rhel
+
+$(ci_manifests): hack/generate-configmap.sh $(ci_keys) $(ci_stores)
+	$< --ci
+
+$(rhel_manifests): hack/generate-configmap.sh $(rhel_keys) $(rhel_stores)
+	$< --rhel

--- a/hack/generate-configmap.sh
+++ b/hack/generate-configmap.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+
+# This script generates configmap/s set by arguments
+#
+# To create a CI configmap use the "--ci" option
+# To create an RHEL configmap use the "--rhel" option
+# To create both configmaps use the "--all" option or pass no arguments
+
+set -e
+
+trap teardown EXIT
+
+teardown() {
+	rm -rf "${TEMP_DIR}"
+}
+
+TEMP_DIR=$(mktemp -d -t keys-XXXXXXXX)
+CONFIGMAP_FILENAME="0000_90_cluster-update-keys_configmap.yaml"
+
+# Generates a public key specified by parameters in the TEMP_DIR directory
+#
+# $1 - Filename of the key which will be generated
+# $2 and more - Verifier public keys
+#
+generate_public_key() {
+	key_filename="${1}"; shift
+	rm -f "${TEMP_DIR}/key.gpg"
+	for key in "${@}"; do
+		gpg --dearmor < "${key}" >> "${TEMP_DIR}/key.gpg"
+	done
+	gpg --enarmor < "${TEMP_DIR}/key.gpg" > "${TEMP_DIR}/${key_filename}"
+	sed -i "s/ARMORED FILE/PUBLIC KEY BLOCK/" "${TEMP_DIR}/${key_filename}"
+}
+
+# Generates a configmap specified by parameters
+#
+# $1 - Filename of a generated key in the TEMP_DIR directory
+# $2 - Manifests directory
+# $3 and more - Store files
+#
+generate_configmap() {
+	key_filename="${1}"; shift
+	manifests_dir="${1}"; shift
+
+	stores=()
+	for store in "${@}"; do
+		stores+=("--from-file=${store}")
+	done
+
+	oc create configmap release-verification -n openshift-config-managed \
+		--from-file="${TEMP_DIR}/${key_filename}" \
+		"${stores[@]}" \
+		--dry-run=client -o yaml |
+		oc annotate -f - release.openshift.io/verification-config-map= \
+			include.release.openshift.io/ibm-cloud-managed=true \
+			include.release.openshift.io/self-managed-high-availability=true \
+			include.release.openshift.io/single-node-developer=true \
+			-n openshift-config-managed --local --dry-run=client -o yaml \
+			>>"${manifests_dir}/${CONFIGMAP_FILENAME}"
+}
+
+# Generates a CI configmap
+#
+generate_ci_configmap() {
+	configmap_data_key="verifier-public-key-ci"
+	manifests_dir="manifests/"
+	keys=("keys/verifier-public-key-openshift-ci" "keys/verifier-public-key-openshift-ci-2")
+	stores=("stores/store-openshift-ci-release")
+
+	generate_public_key \
+		"${configmap_data_key}" \
+		"${keys[@]}"
+
+	echo "# Release verification against OpenShift CI keys signed by the CI infrastructure" \
+		>"${manifests_dir}/${CONFIGMAP_FILENAME}"
+
+	generate_configmap \
+		"${configmap_data_key}" \
+		"${manifests_dir}" \
+		"${stores[@]}"
+}
+
+# Generates a RHEL configmap
+#
+generate_rhel_configmap() {
+	configmap_data_key="verifier-public-key-redhat"
+	manifests_dir="manifests.rhel/"
+	keys=("keys/verifier-public-key-redhat-release" "keys/verifier-public-key-redhat-beta-2")
+	stores=("stores/store-openshift-official-release" "stores/store-openshift-official-release-mirror")
+
+	generate_public_key \
+		"${configmap_data_key}" \
+		"${keys[@]}"
+
+	echo "# Release verification against Official Red Hat keys" \
+		>"${manifests_dir}/${CONFIGMAP_FILENAME}"
+
+	generate_configmap \
+		"${configmap_data_key}" \
+		"${manifests_dir}" \
+		"${stores[@]}"
+}
+
+main() {
+	if [ "$#" -eq "0" ]; then
+		set -- --all
+	fi
+
+	while test "${#}" -gt 0; do
+		case "${1}" in
+		--ci)
+			generate_ci_configmap
+			shift
+			;;
+		--rhel)
+			generate_rhel_configmap
+			shift
+			;;
+		--all)
+			generate_ci_configmap
+			generate_rhel_configmap
+			shift
+			;;
+		*)
+			echo "unrecognized argument: ${1}" >&2
+			exit 1
+			;;
+		esac
+	done
+}
+
+main "$@"

--- a/hack/verify-configmaps.sh
+++ b/hack/verify-configmaps.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+./hack/generate-configmap.sh && git diff --exit-code

--- a/manifests.rhel/0000_90_cluster-update-keys_configmap.yaml
+++ b/manifests.rhel/0000_90_cluster-update-keys_configmap.yaml
@@ -67,4 +67,3 @@ metadata:
   creationTimestamp: null
   name: release-verification
   namespace: openshift-config-managed
-  namespace: openshift-config-managed


### PR DESCRIPTION
Add bash script `hack/generate-configmap.sh` generating configMaps which were previously generated by the `Makefile`.
Modify `Makefile` to call the new bash script.
Add a bash test script `hack/test-generate-configmap.sh` to ensure the configMaps are generated correctly.
Modify `manifests.rhel/0000_90_cluster-update-keys_configmap.yaml` to remove duplicate line.

Pull request related to https://issues.redhat.com/browse/OTA-409