### PR TITLE
OCPNODE-3978: Extend the default ClusterImagePolicy for openshift component images

### DIFF
--- a/manifests.rhel/0000_90_openshift-cluster-image-policy.yaml
+++ b/manifests.rhel/0000_90_openshift-cluster-image-policy.yaml
@@ -9,6 +9,8 @@ metadata:
 spec:
   scopes:
   - quay.io/openshift-release-dev/ocp-release
+  - quay.io/openshift-release-dev/ocp-v4.0-art-dev
+  - quay.io/openshift-release-dev/ocp-v5.0-art-dev
   policy:
     rootOfTrust:
       policyType: PublicKey


### PR DESCRIPTION
- Expand default Sigstore verification scope for `quay.io/openshift-release-dev/ocp-v4.0-art-dev` to include all OpenShift controller component images.
- Add `quay.io/openshift-release-dev/ocp-v5.0-art-dev` in preparation for future v5 repositories hosting signed images.
- As suggested by @jupierce, "There are other repos in quay.io/openshift-release-dev that don't have signed images.",
we intentionally aovid scoping to broader `quay.io/openshift-release-dev` namespace, since not all repositories under it publish signed images.