### PR TITLE
OCPNODE-3006: Drop openshift policy to DevPreviewNoUpgrade for ClusterImagePolicy to v1 

### DIFF
--- a/manifests.rhel/0000_90_openshift-cluster-image-policy.yaml
+++ b/manifests.rhel/0000_90_openshift-cluster-image-policy.yaml
@@ -6,7 +6,7 @@ metadata:
     kubernetes.io/description: Require Red Hat signatures for quay.io/openshift-release-dev/ocp-release container images.
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
-    release.openshift.io/feature-set: TechPreviewNoUpgrade
+    release.openshift.io/feature-set: DevPreviewNoUpgrade
 spec:
   scopes:
   - quay.io/openshift-release-dev/ocp-release


### PR DESCRIPTION

openshift/api#2384 moves clusterimagepolicy to v1 has below e2e-aws-ovn-techpreview failure. This PR drops openshift policy to DevPreviewNoUpgrade, so it will not install on TechPreviewNoUpgrade environment during the process of moving ClusterImagePolicy to v1 from v1alpha1. Will add back openshift on v1 ClusterImagePolicy openshift/cluster-update-keys#74 back to TechPreviewNoUpgrade after 
openshift/api#2384
openshift/machine-config-operator#5143
[openshift/origin#29973](https://github.com/openshift/origin/pull/29973)


```
build 4.20.0-0.nightly-2025-07-15-083124, openshift/api#2384
[core@ip-10-0-163-242 ~]$ journalctl -b -f -u release-image.service -u bootkube.service
Jul 19 00:45:53 ip-10-0-163-242 bootkube.sh[4890]: [#14624] failed to create some manifests:
Jul 19 00:45:53 ip-10-0-163-242 bootkube.sh[4890]: "0000_90_openshift-cluster-image-policy.yaml": unable to get REST mapping for "0000_90_openshift-cluster-image-policy.yaml": no matches for kind "ClusterImagePolicy" in version "config.openshift.io/v1alpha1"
```
