### PR TITLE
NO-ISSUE: OWNERS: Add Mrunal, remove folks who are no longer active in OpenShift-core

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,12 +1,7 @@
 approvers:
-- deads2k
-- sdodson
-- bparees
-- dhellmann
 - jupierce
-reviewers:
-- deads2k
+- mrunalp
 - sdodson
-- dhellmann
-- bparees
+reviewers:
+- sdodson
 - wking


### PR DESCRIPTION
* Ben moved to OpenShift Lightspeed.
* David's shifted over to work with managed services.
* Doug moved to help on some AI projects.

Adding @mrunalp at @jupierce's suggestion, to keep enough folks in the approver list to allow calm responses in the face of time-off, etc.