### PR TITLE
OCPNODE-3611: manifests.rhel/0000_90_openshift-cluster-image-policy: Drop TechPreviewNoUpgrade limitation

### DIFF
--- a/manifests.rhel/0000_90_openshift-cluster-image-policy.yaml
+++ b/manifests.rhel/0000_90_openshift-cluster-image-policy.yaml
@@ -6,7 +6,6 @@ metadata:
     kubernetes.io/description: Require Red Hat signatures for quay.io/openshift-release-dev/ocp-release container images.
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
-    release.openshift.io/feature-set: TechPreviewNoUpgrade
 spec:
   scopes:
   - quay.io/openshift-release-dev/ocp-release


### PR DESCRIPTION
Now that ClusterImagePolicy is v1 and in the default feature set, we can remove [the annotation that limites the openshift ClusterImagePolicy to the TechPreviewNoUpgrade feature set](https://github.com/openshift/cluster-update-keys/blob/569dfed552ceeeeea1dd3dd5f97b33e3a5703137/manifests.rhel/0000_90_openshift-cluster-image-policy.yaml#L9).  No CI impact is expected, because even [4.y.z release-controller jobs](https://amd64.ocp.releases.ci.openshift.org/releasestream/4-stable/release/4.19.9) like [4.19.8 -> 4.19.9](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/release-openshift-origin-installer-e2e-aws-upgrade/1956054636976672768) use imported-into-CI-registry versions of the target release [like](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/logs/release-openshift-origin-installer-e2e-aws-upgrade/1956054636976672768/artifacts/e2e-aws-upgrade/clusterversion.json) [registry.ci.openshift.org/ocp/release:4.19.9](http://registry.ci.openshift.org/ocp/release:4.19.9). But it sets us up for being able to drop OpenPGP/GPG signature verification in future releases, and avoids the risk that a 4.20 customer creates their own openshift ClusterImagePolicy and the resulting de-conflicting guards we'd need on 4.20-to-4.21 updates.