### PR TITLE
Revert "OCPNODE-3611: manifests.rhel/0000_90_openshift-cluster-image-policy: Drop TechPreviewNoUpgrade limitation"

### DIFF
--- a/manifests.rhel/0000_90_openshift-cluster-image-policy.yaml
+++ b/manifests.rhel/0000_90_openshift-cluster-image-policy.yaml
@@ -6,6 +6,7 @@ metadata:
     kubernetes.io/description: Require Red Hat signatures for quay.io/openshift-release-dev/ocp-release container images.
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
 spec:
   scopes:
   - quay.io/openshift-release-dev/ocp-release


### PR DESCRIPTION
Reverts openshift/cluster-update-keys#82

This was tripping up CI by causing a new MachineConfigPool rollout late in the update.  For example, [this run][1], had:

1. 0:55:22 UTC, [`rendered-master-5d3ab69b0a03bc70fa37249f040c06b4` MachineConfig created][4] to push out the version bump.
1. 1:19:15 (and 1:19:20?) UTC, [`OperatorVersionChanged` Events claimed the `machine-config` ClusterOperator finished its transition][3].
1. 1:19:47 UTC, [ClusterVersion claimed the update completed][2].
1. 1:19:49 UTC, [`rendered-master-975808f8abad8954df577f74c6809db3` MachineConfig created][5].
1. CI fails with:

    ```
    : [sig-arch][Feature:ClusterUpgrade] Cluster should remain functional during upgrade [Disruptive] [Serial]	1h14m13s
    {  fail [github.com/openshift/origin/test/e2e/upgrade/upgrade.go:187]: during upgrade to registry.build11.ci.openshift.org/ci-op-cy2jcwgs/release@sha256:8cf00e640f46548e76028aa258ddddaaad987edb39e8399fc791b305321b4877: the "master" pool should be updated before the CVO reports available at the new version}
    ```

Confirming that the difference between those MachineConfig is the `openshift` ClusterImagePolicy:

```console
$ diff -U3 <(curl -s https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.20-e2e-aws-ovn-upgrade-fips/1960838341934977024/artifacts/e2e-aws-ovn-upgrade-fips/gather-extra/artifacts/inspect/cluster-scoped-resources/machineconfiguration.openshift.io/machineconfigs/rendered-master-5d3ab69b0a03bc70fa37249f040c06b4.yaml | yaml2json | jq -r '.spec.config.storage.files[] | select(.path == "/etc/containers/policy.json").contents.source | split(",")[-1]' | python3 -c 'import urllib.parse, sys; print(urllib.parse.unquote(sys.stdin.read()))') <(curl -s https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.20-e2e-aws-ovn-upgrade-fips/1960838341934977024/artifacts/e2e-aws-ovn-upgrade-fips/gather-extra/artifacts/inspect/cluster-scoped-resources/machineconfiguration.openshift.io/machineconfigs/rendered-master-975808f8abad8954df577f74c6809db3.yaml | yaml2json | jq -r '.spec.config.storage.files[] | select(.path == "/etc/containers/policy.json").contents.source | split(",")[-1] | @base64d')
--- /dev/fd/63  2025-08-28 00:44:33.542232745 -0700
+++ /dev/fd/62  2025-08-28 00:44:33.547232745 -0700
@@ -1,15 +1,38 @@
 {
-    "default": [
+  "default": [
+    {
+      "type": "insecureAcceptAnything"
+    }
+  ],
+  "transports": {
+    "atomic": {
+      "quay.io/openshift-release-dev/ocp-release": [
         {
...
```

[1]: https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.20-e2e-aws-ovn-upgrade-fips/1960838341934977024
[2]: https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.20-e2e-aws-ovn-upgrade-fips/1960838341934977024/artifacts/e2e-aws-ovn-upgrade-fips/gather-extra/artifacts/inspect/cluster-scoped-resources/config.openshift.io/clusterversions.yaml
[3]: https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.20-e2e-aws-ovn-upgrade-fips/1960838341934977024/artifacts/e2e-aws-ovn-upgrade-fips/gather-extra/artifacts/inspect/namespaces/openshift-machine-config-operator/core/events.yaml
[4]: https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.20-e2e-aws-ovn-upgrade-fips/1960838341934977024/artifacts/e2e-aws-ovn-upgrade-fips/gather-extra/artifacts/inspect/cluster-scoped-resources/machineconfiguration.openshift.io/machineconfigs/rendered-master-5d3ab69b0a03bc70fa37249f040c06b4.yaml
[5]: https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.20-e2e-aws-ovn-upgrade-fips/1960838341934977024/artifacts/e2e-aws-ovn-upgrade-fips/gather-extra/artifacts/inspect/cluster-scoped-resources/machineconfiguration.openshift.io/machineconfigs/rendered-master-975808f8abad8954df577f74c6809db3.yaml