### PR TITLE
OTA-1773: manifests*/0000_90_cluster-update-keys_configmap: New release-repository-*

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,22 +6,21 @@ The config map must have the annotation `release.openshift.io/verification-confi
 
 The keys within the config map define how verification is performed:
 
-```
-verifier-public-key-*: One or more GPG public keys in ASCII form that must have signed the
-                       release image by digest.
+* `verifier-public-key-*`: One or more GPG public keys in ASCII form that must have signed the release image by digest.
+* `store-*`: A URL (scheme file://, http://, or https://) location that contains signatures.
+    These signatures are in the atomic container signature format.
+    The URL will have the digest of the image appended to it as `<STORE>/<ALGO>=<DIGEST>/signature-<NUMBER>` as described in [the container image signing format][signature-protocols].
+    The `docker-image-manifest` section of the signature must match the release image digest.
+    Signatures are searched starting at `NUMBER` 1 and incrementing if the signature exists but is not valid.
+    The signature is a GPG signed and encrypted JSON message.
+    The file store is provided for testing only at the current time, although future versions of the CVO might allow host mounting of signatures.
+* `release-repository-*`: In addition to checking for valid OpenPGP signatures, the cluster-version operator will also require the that target release image pullspec matches one of these expected registries.
+    This supports an eventual transition from OpenPGP signatures to Sigstore signatures, where:
+    * ClusterImagePolicies such as [the `openshift` policy](manifests.rhel/0000_90_openshift-cluster-image-policy.yaml) cover authentication ("yes, the configured policy for that scope asserts that the image is actually `quay.io/openshift-release-dev/ocp-release@sha256:a29b...`" vs. "no, the configured policy for that scope fails on `quay.io/openshift-release-dev/ocp-release@sha256:0000...`, it might be malicious or corrupted").
+    * The release pullspec check covers authorization ("yes, `quay.io/openshift-release-dev/ocp-release` is the expected repository for OCP releases" vs. "no, `quay.io/okd/scos-release` is not the expected repository for OCP release, you probably don't want to update your OCP cluster to an OKD release image").
 
-store-*: A URL (scheme file://, http://, or https://) location that contains signatures. These
-         signatures are in the atomic container signature format. The URL will have the digest
-         of the image appended to it as "<STORE>/<ALGO>=<DIGEST>/signature-<NUMBER>" as described
-         in the container image signing format. The docker-image-manifest section of the
-         signature must match the release image digest. Signatures are searched starting at
-         NUMBER 1 and incrementing if the signature exists but is not valid. The signature is a
-         GPG signed and encrypted JSON message. The file store is provided for testing only at
-         the current time, although future versions of the CVO might allow host mounting of
-         signatures.
-```
+[OKD builds][OKD] are signed with CI release key and signatures updated to `openshift-ci-release` GCS bucket.
+Official OCP builds are signed with Red Hat release key, signatures uploaded to `openshift-release` GCS bucket and mirrored to https://mirror.openshift.com/pub/openshift-v4/signatures/openshift/release/
 
-See https://github.com/containers/image/blob/ab49b0a48428c623a8f03b41b9083d48966b34a9/docs/signature-protocols.md for a description of the signature store.
-
-The OpenShift CI system uses the public key described here and signs releases at https://amd64.ocp.releases.ci.openshift.org/ once they are created. Nightly and OKD builds are signed with CI release key and signatures updated to openshift-ci-release GCS bucket/.
-Official OCP builds are signed with Red Hat release key, signatures uploaded to openshift-release GCS bucket and mirrored to https://mirror.openshift.com/pub/openshift-v4/signatures/openshift/release
+[signature-protocols]: https://github.com/containers/image/blob/ab49b0a48428c623a8f03b41b9083d48966b34a9/docs/signature-protocols.md
+[OKD]: https://amd64.origin.releases.ci.openshift.org/

--- a/manifests.rhel/0000_90_cluster-update-keys_configmap.yaml
+++ b/manifests.rhel/0000_90_cluster-update-keys_configmap.yaml
@@ -69,4 +69,3 @@ metadata:
   creationTimestamp: null
   name: release-verification
   namespace: openshift-config-managed
-  namespace: openshift-config-managed

--- a/manifests.rhel/0000_90_cluster-update-keys_configmap.yaml
+++ b/manifests.rhel/0000_90_cluster-update-keys_configmap.yaml
@@ -1,6 +1,7 @@
 # Release verification against Official Red Hat keys
 apiVersion: v1
 data:
+  release-repository-default: quay.io/openshift-release-dev/ocp-release
   store-openshift-official-release: https://storage.googleapis.com/openshift-release/official/signatures/openshift/release
   store-openshift-official-release-mirror: https://mirror.openshift.com/pub/openshift-v4/signatures/openshift/release
   verifier-public-key-redhat: |

--- a/manifests/0000_90_cluster-update-keys_configmap.yaml
+++ b/manifests/0000_90_cluster-update-keys_configmap.yaml
@@ -1,6 +1,7 @@
 # Release verification against OpenShift CI keys signed by the CI infrastructure
 apiVersion: v1
 data:
+  release-repository-default: quay.io/okd/scos-release
   store-openshift-ci-release: https://storage.googleapis.com/openshift-ci-release/releases/signatures/openshift/release
   verifier-public-key-ci: |
     -----BEGIN PGP PUBLIC KEY BLOCK-----


### PR DESCRIPTION
Preparation for Sigstore, as described in the README text I'm adding:

> * `release-repository-*`: In addition to checking for valid OpenPGP signatures, the cluster-version operator will also require the that target release image pullspec matches one of these expected registries.
>    This supports an eventual transition from OpenPGP signatures to Sigstore signatures, where:
>    * ClusterImagePolicies such as [the `openshift` policy](https://github.com/openshift/cluster-update-keys/blob/b3cae8f22b51d9062d0ceb6ac9cf2f7651b4ce8f/manifests.rhel/0000_90_openshift-cluster-image-policy.yaml) cover authentication ("yes, the configured policy for that scope asserts that the image is actually `quay.io/openshift-release-dev/ocp-release@sha256:a29b...`" vs. "no, the configured policy for that scope fails on `quay.io/openshift-release-dev/ocp-release@sha256:0000...`, it might be malicious or corrupted").
>    * The release pullspec check covers authorization ("yes, `quay.io/openshift-release-dev/ocp-release` is the expected repository for OCP releases" vs. "no, `quay.io/okd/scos-release` is not the expected repository for OCP release, you probably don't want to update your OCP cluster to an OKD release image").

Also some other modernization of README text; details in the commit messages :) 