### PR TITLE
manifests.rhel/0000_90_openshift-cluster-image-policy: Install on HyperShift too

### DIFF
--- a/manifests.rhel/0000_90_openshift-cluster-image-policy.yaml
+++ b/manifests.rhel/0000_90_openshift-cluster-image-policy.yaml
@@ -4,7 +4,7 @@ metadata:
   name: openshift
   annotations:
     kubernetes.io/description: Require Red Hat signatures for quay.io/openshift-release-dev/ocp-release container images.
-    exclude.release.openshift.io/internal-openshift-hosted: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
 spec:
   scopes:


### PR DESCRIPTION


The old hosted-exclusion line goes back to file creation in 38348960a4 (#58), but I'm not sure what I'd been thinking then.  [The enhancement says][1]:

```markdown
#### Hypershift / Hosted Control Planes

HyperShift clusters run pods [on the management cluster and in the hosted cluster][hypershift-concepts].
A ClusterImagePolicy applied to the hosted Kubernetes API server will only be distributed to hosted nodes, and none of those nodes are likely to run an image from `quay.io/openshift-release-dev/ocp-release` (platform DaemonSets will use `quay.io/openshift-release-dev/ocp-v4.0-art-dev` images referenced from the `quay.io/openshift-release-dev/ocp-release` image).
However, a ClusterImagePolicy applied to the management cluster's Kubernetes API server would cover both the management cluster's cluster-version operator (CVO), and the CVOs associated with hosted clusters (which run as pods in mangement-cluster namespaces).
That means that it would take an ImagePolicy to be able to distinguish between constraints on the management cluster's CVO and constraints on the hosted components running on the management cluster, which is [out of scope for this enhancement](#use-an-imagepolicy-for-openshift--namespaces).
```

Which sounds like "doesn't really matter" for 4.21, where only `quay.io/openshift-release-dev/ocp-release` is covered.  But it matters now on 4.22, where 0204c8b3e8 (#97) extends that coverage to `quay.io/openshift-release-dev/ocp-v4.0-art-dev` and `quay.io/openshift-release-dev/ocp-v5.0-art-dev`.

[1]: https://github.com/openshift/enhancements/blame/c124f770ac107dad2f8b19548ef7fa2c0d837166/enhancements/security/openshift-image-policy.md#L103-L108

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated cluster image policy configuration to modify image source allowance behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->